### PR TITLE
New params for watermarks and imagine

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -311,6 +311,7 @@ export class IMGProcessingClient {
     negative_prompt,
     name,
     seed,
+    model
   }: IMGProcessingClient.imagine.Params): Promise<ImageObject> {
     return this.imageRequest(() =>
       this.client.post<ImageObject>("v1/images/imagine", {
@@ -319,6 +320,7 @@ export class IMGProcessingClient {
           negative_prompt,
           name,
           seed,
+          model
         },
       }),
     );
@@ -619,6 +621,8 @@ export declare namespace IMGProcessingClient {
       name: string;
       /** The seed to use for the generation. */
       seed?: number;
+      /** The model to use for the generation. */
+      model?: "sdxl" | "flux"
     };
   }
 
@@ -729,9 +733,15 @@ export declare namespace IMGProcessingClient {
         /** The unique identifier of the image to use as a watermark. */
         id: ImageId;
         /** The position of the watermark from the left of the image to apply the watermark. */
-        left: number;
+        left?: number;
         /** The position of the watermark from the top of the image to apply the watermark. */
-        top: number;
+        top?: number;
+        /** The width of the watermark to apply to the image. */
+        width?: number;
+        /** The height of the watermark to apply to the image. */
+        height?: number;
+        /** The repetition mode of the watermark. If not provided, the watermark will be applied once. */
+        repetition_mode?: "no_repeat" | "repeat" | "repeat_x" | "repeat_y";
       }[];
       /** The name of the image. If not provided, the original image name will be used. */
       name?: string;

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -717,8 +717,6 @@ export declare namespace IMGProcessingClient {
       angle: number;
       /** The unit of the angle. Default is `degrees`. */
       unit?: "degrees" | "radians";
-      /** The background color to fill the empty areas after rotating the image. Default is `#000000`. */
-      background_color?: string;
       /** The name of the image. If not provided, the original image name will be used. */
       name?: string;
     };

--- a/src/image-object.ts
+++ b/src/image-object.ts
@@ -313,14 +313,12 @@ export class ImageObject<
     angle,
     unit,
     name,
-    background_color,
   }: ImageObject.rotate.Params): Promise<ImageObject> {
     return await this.client.rotate({
       image_id: this.id,
       angle,
       unit,
       name,
-      background_color,
     });
   }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `IMGProcessingClient` and `ImageObject` classes in the `src/api-client.ts` and `src/image-object.ts` files. The main changes include adding new parameters, making some parameters optional, and removing an unused parameter.

### Updates to `IMGProcessingClient`:

* Added `model` parameter to the `imagine` method to specify the model for image generation. * Introduced `model` property to the `IMGProcessingClient.imagine.Params` interface, allowing the selection between "sdxl" and "flux" models.
* Removed the `background_color` property from the `rotate.Params` interface, simplifying the parameters for image rotation.
* Made `left` and `top` properties optional in the `watermark.Params` interface and added new properties for `width`, `height`, and `repetition_mode` to enhance watermark customization.

### Updates to `ImageObject`:

* Removed the `background_color` parameter from the `rotate` method, aligning with the changes in `IMGProcessingClient`.